### PR TITLE
Add keycode for "twosuperior" on Linux

### DIFF
--- a/includes/OISKeyboard.h
+++ b/includes/OISKeyboard.h
@@ -175,7 +175,7 @@ namespace OIS
 		KC_MYCOMPUTER  = 0xEB,    // My Computer
 		KC_MAIL        = 0xEC,    // Mail
 		KC_MEDIASELECT = 0xED,    // Media Select
-        KC_TWOSUPERIOR = 0xF0,    // ² on French AZERTY keyboard (same place as ~ ` on QWERTY)
+		KC_TWOSUPERIOR = 0xF0,    // ² on French AZERTY keyboard (same place as ~ ` on QWERTY)
 	};
 
 	/**

--- a/includes/OISKeyboard.h
+++ b/includes/OISKeyboard.h
@@ -174,7 +174,8 @@ namespace OIS
 		KC_WEBBACK     = 0xEA,    // Web Back
 		KC_MYCOMPUTER  = 0xEB,    // My Computer
 		KC_MAIL        = 0xEC,    // Mail
-		KC_MEDIASELECT = 0xED     // Media Select
+		KC_MEDIASELECT = 0xED,    // Media Select
+        KC_SQUARE      = 0xF0,    // ² on French AZERTY keyboard (same place as ~ ` on QWERTY)
 	};
 
 	/**

--- a/includes/OISKeyboard.h
+++ b/includes/OISKeyboard.h
@@ -175,7 +175,7 @@ namespace OIS
 		KC_MYCOMPUTER  = 0xEB,    // My Computer
 		KC_MAIL        = 0xEC,    // Mail
 		KC_MEDIASELECT = 0xED,    // Media Select
-        KC_SQUARE      = 0xF0,    // ² on French AZERTY keyboard (same place as ~ ` on QWERTY)
+        KC_TWOSUPERIOR = 0xF0,    // ² on French AZERTY keyboard (same place as ~ ` on QWERTY)
 	};
 
 	/**

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -183,6 +183,8 @@ LinuxKeyboard::LinuxKeyboard(InputManager* creator, bool buffered, bool grab)
 	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Super_R, KC_RWIN));
 	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Menu, KC_APPS));
 
+	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_twosuperior, KC_TWOSUPERIOR));
+
 	static_cast<LinuxInputManager*>(mCreator)->_setKeyboardUsed(true);
 }
 


### PR DESCRIPTION
Hi,
This pull request just simply add a keycode for the "²" key on Linux. This is useful if you are using an AZERTY layout, since it's the key that most games and game-engine would use to bring up an in-game debug console.

This is due to the fact that with Xorg, keyboard layout, keycode and keysyms move around quite a bit, and it's a pain in the neck.

I know that this library is old and mostly unmaintained, but here seemed to be the most appropriate place to send a patch...

(`0xF0` is choosen totaly at random, and absolutely not because it's the name of a cool video game and was still free)